### PR TITLE
respect custom basepaths

### DIFF
--- a/src/project/panes/App/index.html
+++ b/src/project/panes/App/index.html
@@ -142,10 +142,16 @@
 			},
 
 			async editPage() {
-				const { dir } = this.store.get();
+				const { basepath = '', dir } = this.store.get();
 				const { find_page } = relative('sapper/api.js', dir);
-				const { status: pathname } = this.get(); // bit of a hack — proxy for pathname
 				const files = glob('**', { cwd: path.resolve(dir, 'routes'), filesOnly: true, dot: true });
+
+				let { status: pathname } = this.get(); // bit of a hack — proxy for pathname
+
+				if (pathname.startsWith(basepath)) {
+					pathname = pathname.slice(basepath.length);
+				}
+
 				const page = find_page(pathname, files);
 
 				if (page) {

--- a/src/project/store.ts
+++ b/src/project/store.ts
@@ -93,12 +93,11 @@ class StudioStore extends Store {
 					break;
 
 				case 'error':
-				console.log(`error ${message.error.message}`);
+					console.log(`error ${message.error.message}`);
 					break;
 
 				case 'ready':
 					setTimeout(() => {
-						console.log('message', message.port);
 						this.set({
 							startingDev: false,
 							runningDev: true,
@@ -108,6 +107,10 @@ class StudioStore extends Store {
 							port: message.port
 						});
 					});
+					break;
+
+				case 'basepath':
+					this.set({ basepath: message.event.basepath });
 
 					break;
 			}

--- a/workers/sapper-dev.js
+++ b/workers/sapper-dev.js
@@ -19,30 +19,11 @@ watcher.on('ready', event => {
 	});
 });
 
-watcher.on('error', event => {
-	process.send({
-		type: 'error',
-		event
-	});
-});
-
-watcher.on('fatal', event => {
-	process.send({
-		type: 'fatal',
-		event
-	});
-});
-
-watcher.on('invalid', event => {
-	process.send({
-		type: 'invalid',
-		event
-	});
-});
-
-watcher.on('build', event => {
-	process.send({
-		type: 'build',
-		event
+['error', 'fatal', 'invalid', 'build', 'basepath'].forEach(type => {
+	watcher.on(type, event => {
+		process.send({
+			type,
+			event
+		});
 	});
 });


### PR DESCRIPTION
Depends on https://github.com/sveltejs/sapper/pull/284. Allows the edit button in the App pane to work even when paths are prefixed with a basepath.