### PR TITLE
Set the fontFamily on the instantiation of the monaco editor.

### DIFF
--- a/pages/editor/editor.js
+++ b/pages/editor/editor.js
@@ -65,7 +65,8 @@ amdRequire(['vs/editor/editor.main'], function() {
 	editor = monaco.editor.create(container, {
 		value: initial.value || '',
 		language: initial.lang || 'javascript',
-		theme: "vs-dark"
+		theme: "vs-dark",
+		fontFamily: "Fira Code"
 	});
 
 	if (initial.loc) {


### PR DESCRIPTION
Set the fontFamily on the instantiation of the monaco editor.  This resolves a bug in windows where the cursor gets placed to the left of where it should be.