### PR TITLE
Fix case-sensitivity typo

### DIFF
--- a/src/project/Pane.html
+++ b/src/project/Pane.html
@@ -89,7 +89,7 @@
 
 		{
 			name: 'Server logs',
-			fn: () => import('./panes/logs/index.html')
+			fn: () => import('./panes/Logs/index.html')
 		}
 	];
 


### PR DESCRIPTION
This typo prevents running on case-sensitive systems such as most Linux systems.